### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
         "project_name": ""
     },
     "description": "Import Pointcloud Episodes with Annotations and Photo context",
-    "docker_image": "supervisely/import-export:6.73.511",
+    "docker_image": "supervisely/import-export:6.73.564",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",
     "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
     "isolate": true,
     "headless": true,
     "min_agent_version": "6.7.4",
-    "min_instance_version": "6.15.40",
+    "instance_version": "6.15.60",
     "icon": "https://github.com/supervisely-ecosystem/import-pointcloud-episode/releases/download/v1.0.0/icon.png",
     "icon_cover": true,
     "icon_background": "#FFFFFF",

--- a/config.json
+++ b/config.json
@@ -1,35 +1,35 @@
 {
-    "name": "Import Pointcloud Episodes",
-    "type": "app",
-    "categories": [
-        "import",
-        "pointclouds",
-        "essentials"
-    ],
-    "modal_template_state": {
-        "remove_source": true,
-        "project_name": ""
-    },
-    "description": "Import Pointcloud Episodes with Annotations and Photo context",
-    "docker_image": "supervisely/import-export:6.73.564",
-    "main_script": "src/main.py",
-    "modal_template": "src/modal.html",
-    "task_location": "workspace_tasks",
-    "isolate": true,
-    "headless": true,
-    "min_agent_version": "6.7.4",
-    "instance_version": "6.15.60",
-    "icon": "https://github.com/supervisely-ecosystem/import-pointcloud-episode/releases/download/v1.0.0/icon.png",
-    "icon_cover": true,
-    "icon_background": "#FFFFFF",
-    "context_menu": {
-        "context_category": "Import",
-        "target": [
-            "files_folder",
-            "files_file",
-            "agent_folder",
-            "agent_file"
-        ]
-    },
-    "poster": "https://github.com/supervisely-ecosystem/import-pointcloud-episode/releases/download/v1.0.0/poster.png"
+  "name": "Import Pointcloud Episodes",
+  "type": "app",
+  "categories": [
+    "import",
+    "pointclouds",
+    "essentials"
+  ],
+  "modal_template_state": {
+    "remove_source": true,
+    "project_name": ""
+  },
+  "description": "Import Pointcloud Episodes with Annotations and Photo context",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "main_script": "src/main.py",
+  "modal_template": "src/modal.html",
+  "task_location": "workspace_tasks",
+  "isolate": true,
+  "headless": true,
+  "min_agent_version": "6.7.4",
+  "instance_version": "6.15.60",
+  "icon": "https://github.com/supervisely-ecosystem/import-pointcloud-episode/releases/download/v1.0.0/icon.png",
+  "icon_cover": true,
+  "icon_background": "#FFFFFF",
+  "context_menu": {
+    "context_category": "Import",
+    "target": [
+      "files_folder",
+      "files_file",
+      "agent_folder",
+      "agent_file"
+    ]
+  },
+  "poster": "https://github.com/supervisely-ecosystem/import-pointcloud-episode/releases/download/v1.0.0/poster.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.511
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
